### PR TITLE
[FIX] Show trouble shootings directly

### DIFF
--- a/src/components/portfolio/ShowMore.js
+++ b/src/components/portfolio/ShowMore.js
@@ -29,7 +29,11 @@ function ShowMore(props) {
             alert(error.response.data.data.errors[0].message);
           }
         });
-      scrollTS.current.scrollIntoView();
+      scrollTS.current.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+        inline: "nearest",
+      });
     }
     if (!show) {
       setTroubleShootings([]);


### PR DESCRIPTION
trouble shootings component didn't show up directly to client when button clicked
It is a scroll issue